### PR TITLE
Fix use_madgwic_filter arg parsing

### DIFF
--- a/husarion_ugv_description/urdf/lynx.urdf.xacro
+++ b/husarion_ugv_description/urdf/lynx.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:arg name="battery_config_file"
     default="" />
   <xacro:arg name="namespace" default="" />
-
+  <xacro:arg name="use_madgwick_filter" default="false" />
 
   <xacro:include filename="$(find husarion_ugv_description)/urdf/lynx/lynx_macro.urdf.xacro" ns="husarion" />
   <xacro:husarion.lynx_robot
@@ -21,7 +21,8 @@
     wheel_config_file="$(arg wheel_config_file)"
     controller_config_file="$(arg controller_config_file)"
     battery_config_file="$(arg battery_config_file)"
-    namespace="$(arg namespace)" />
+    namespace="$(arg namespace)"
+    use_madgwick_filter="$(arg use_madgwick_filter)" />
 
   <xacro:arg name="components_config_path" default="$(find husarion_ugv_description)/config/components.yaml" />
   <xacro:property name="components_config_path_property" value="$(arg components_config_path)" />

--- a/husarion_ugv_description/urdf/panther.urdf.xacro
+++ b/husarion_ugv_description/urdf/panther.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:arg name="battery_config_file"
     default="" />
   <xacro:arg name="namespace" default="" />
-
+  <xacro:arg name="use_madgwick_filter" default="false" />
 
   <xacro:include filename="$(find husarion_ugv_description)/urdf/panther/panther_macro.urdf.xacro" ns="husarion" />
   <xacro:husarion.panther_robot
@@ -21,7 +21,8 @@
     wheel_config_file="$(arg wheel_config_file)"
     controller_config_file="$(arg controller_config_file)"
     battery_config_file="$(arg battery_config_file)"
-    namespace="$(arg namespace)" />
+    namespace="$(arg namespace)"
+    use_madgwick_filter="$(arg use_madgwick_filter)" />
 
   <xacro:arg name="components_config_path" default="$(find husarion_ugv_description)/config/components.yaml" />
   <xacro:property name="components_config_path_property" value="$(arg components_config_path)" />


### PR DESCRIPTION
### Description

- Parameter was not propagated correctly, causing all nans in orientation. This fixes the issue.

### Requirements

- [ ] (Dependency PR)
- [ ] Backport
- [ ] Code style guidelines followed
- [ ] Documentation updated
- [ ] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [ ] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to enable the Madgwick filter for Lynx and Panther robot configurations.
  * The filter remains disabled by default for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->