### PR TITLE
Fix header inclusion in `lights_driver_node.cpp`

### DIFF
--- a/husarion_ugv_lights/src/lights_driver_node.cpp
+++ b/husarion_ugv_lights/src/lights_driver_node.cpp
@@ -32,7 +32,7 @@
 #include "husarion_ugv_msgs/srv/set_led_brightness.hpp"
 
 #include "husarion_ugv_lights/apa102.hpp"
-#include "husarion_ugv_lights/lights_controller_parameters.hpp"
+#include "husarion_ugv_lights/lights_driver_parameters.hpp"
 
 namespace husarion_ugv_lights
 {


### PR DESCRIPTION
### Description

This file uses the `lights_driver::` namespace, not `lights_controller::`

### Requirements

- [ ] (Dependency PR)
- [ ] Backport
- [ ] Code style guidelines followed
- [ ] Documentation updated
- [ ] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [ ] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated an internal component reference. No observable functionality changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->