### PR TITLE
Modernize `include_directories`

### DIFF
--- a/husarion_ugv/CMakeLists.txt
+++ b/husarion_ugv/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 project(husarion_ugv)
 
 find_package(ament_cmake REQUIRED)

--- a/husarion_ugv_battery/CMakeLists.txt
+++ b/husarion_ugv_battery/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 project(husarion_ugv_battery)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -18,8 +18,6 @@ foreach(PACKAGE IN ITEMS ${PACKAGE_DEPENDENCIES})
   find_package(${PACKAGE} REQUIRED)
 endforeach()
 
-include_directories(include ${husarion_ugv_utils_INCLUDE_DIRS})
-
 add_executable(
   battery_driver_node
   src/main.cpp
@@ -29,6 +27,8 @@ add_executable(
   src/battery_publisher/battery_publisher.cpp
   src/battery_publisher/dual_battery_publisher.cpp
   src/battery_publisher/single_battery_publisher.cpp)
+target_include_directories(battery_driver_node
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 ament_target_dependencies(battery_driver_node ${PACKAGE_DEPENDENCIES})
 
 generate_parameter_library(battery_parameters src/battery_parameters.yaml)
@@ -54,7 +54,7 @@ if(BUILD_TESTING)
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include>)
   ament_target_dependencies(${PROJECT_NAME}_test_battery rclcpp sensor_msgs
-                            husarion_ugv_msgs)
+                            husarion_ugv_msgs husarion_ugv_utils)
 
   ament_add_gtest(${PROJECT_NAME}_test_adc_battery
                   test/battery/test_adc_battery.cpp src/battery/adc_battery.cpp)
@@ -63,7 +63,7 @@ if(BUILD_TESTING)
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include>)
   ament_target_dependencies(${PROJECT_NAME}_test_adc_battery rclcpp sensor_msgs
-                            husarion_ugv_msgs)
+                            husarion_ugv_msgs husarion_ugv_utils)
 
   ament_add_gtest(
     ${PROJECT_NAME}_test_roboteq_battery test/battery/test_roboteq_battery.cpp
@@ -72,8 +72,9 @@ if(BUILD_TESTING)
     ${PROJECT_NAME}_test_roboteq_battery
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include>)
-  ament_target_dependencies(${PROJECT_NAME}_test_roboteq_battery
-                            husarion_ugv_msgs rclcpp sensor_msgs)
+  ament_target_dependencies(
+    ${PROJECT_NAME}_test_roboteq_battery husarion_ugv_msgs husarion_ugv_utils
+    rclcpp sensor_msgs)
 
   ament_add_gtest(
     ${PROJECT_NAME}_test_battery_publisher
@@ -129,8 +130,8 @@ if(BUILD_TESTING)
     src/battery/roboteq_battery.cpp)
   target_include_directories(
     ${PROJECT_NAME}_test_battery_driver_node_adc_dual
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>
-           $<INSTALL_INTERFACE:include>)
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/test)
   ament_target_dependencies(${PROJECT_NAME}_test_battery_driver_node_adc_dual
                             ${PACKAGE_DEPENDENCIES})
   target_link_libraries(${PROJECT_NAME}_test_battery_driver_node_adc_dual
@@ -147,8 +148,8 @@ if(BUILD_TESTING)
     src/battery/roboteq_battery.cpp)
   target_include_directories(
     ${PROJECT_NAME}_test_battery_driver_node_adc_single
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>
-           $<INSTALL_INTERFACE:include>)
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/test)
   ament_target_dependencies(${PROJECT_NAME}_test_battery_driver_node_adc_single
                             ${PACKAGE_DEPENDENCIES})
   target_link_libraries(${PROJECT_NAME}_test_battery_driver_node_adc_single
@@ -165,8 +166,8 @@ if(BUILD_TESTING)
     src/battery/roboteq_battery.cpp)
   target_include_directories(
     ${PROJECT_NAME}_test_battery_driver_node_roboteq
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>
-           $<INSTALL_INTERFACE:include>)
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/test)
   ament_target_dependencies(${PROJECT_NAME}_test_battery_driver_node_roboteq
                             ${PACKAGE_DEPENDENCIES})
   target_link_libraries(${PROJECT_NAME}_test_battery_driver_node_roboteq

--- a/husarion_ugv_bringup/CMakeLists.txt
+++ b/husarion_ugv_bringup/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 project(husarion_ugv_bringup)
 
 find_package(ament_cmake REQUIRED)

--- a/husarion_ugv_controller/CMakeLists.txt
+++ b/husarion_ugv_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 project(husarion_ugv_controller)
 
 find_package(ament_cmake REQUIRED)

--- a/husarion_ugv_description/CMakeLists.txt
+++ b/husarion_ugv_description/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 project(husarion_ugv_description)
 
 find_package(ament_cmake REQUIRED)

--- a/husarion_ugv_diagnostics/CMakeLists.txt
+++ b/husarion_ugv_diagnostics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 
 # Handle superbuild first
 option(USE_SUPERBUILD "Whether or not a superbuild should be invoked" ON)
@@ -30,8 +30,6 @@ foreach(PACKAGE IN ITEMS ${PACKAGE_DEPENDENCIES})
   find_package(${PACKAGE} REQUIRED)
 endforeach()
 
-include_directories(include)
-
 set(CPPUPROFILE_PREFIX ${CMAKE_BINARY_DIR}/ep_cppuprofile/src/ep_cppuprofile)
 set(ENV{PKG_CONFIG_PATH} "${CPPUPROFILE_PREFIX}/lib:$ENV{PKG_CONFIG_PATH}")
 
@@ -41,8 +39,9 @@ generate_parameter_library(system_monitor_parameters
                            src/system_monitor_parameters.yaml)
 
 add_executable(system_monitor_node src/main.cpp src/system_monitor_node.cpp)
-target_include_directories(system_monitor_node
-                           PUBLIC ${CMAKE_INSTALL_PREFIX}/include)
+target_include_directories(
+  system_monitor_node PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+                              ${CMAKE_INSTALL_PREFIX}/include)
 ament_target_dependencies(system_monitor_node ${PACKAGE_DEPENDENCIES})
 target_link_libraries(system_monitor_node system_monitor_parameters
                       PkgConfig::CPPUPROFILE)
@@ -59,16 +58,18 @@ if(BUILD_TESTING)
   ament_add_gmock(
     ${PROJECT_NAME}_test_system_monitor test/unit/test_system_monitor_node.cpp
     src/system_monitor_node.cpp)
-  target_include_directories(${PROJECT_NAME}_test_system_monitor
-                             PUBLIC ${CMAKE_INSTALL_PREFIX}/include)
+  target_include_directories(
+    ${PROJECT_NAME}_test_system_monitor
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_INSTALL_PREFIX}/include)
   ament_target_dependencies(${PROJECT_NAME}_test_system_monitor
                             ament_cmake_gtest ${PACKAGE_DEPENDENCIES})
   target_link_libraries(${PROJECT_NAME}_test_system_monitor
                         system_monitor_parameters PkgConfig::CPPUPROFILE)
 
   ament_add_gmock(${PROJECT_NAME}_test_filesystem test/unit/test_filesystem.cpp)
-  target_include_directories(${PROJECT_NAME}_test_filesystem
-                             PUBLIC ${CMAKE_INSTALL_PREFIX}/include)
+  target_include_directories(
+    ${PROJECT_NAME}_test_filesystem PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+                                            ${CMAKE_INSTALL_PREFIX}/include)
   ament_target_dependencies(${PROJECT_NAME}_test_filesystem ament_cmake_gtest
                             ${PACKAGE_DEPENDENCIES})
 

--- a/husarion_ugv_gazebo/CMakeLists.txt
+++ b/husarion_ugv_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 project(husarion_ugv_gazebo)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -33,10 +33,10 @@ endforeach()
 
 find_package(Qt5 REQUIRED COMPONENTS Core Quick QuickControls2)
 
-include_directories(include ${Qt5Core_INCLUDE_DIRS} ${Qt5Qml_INCLUDE_DIRS}
-                    ${Qt5Quick_INCLUDE_DIRS} ${Qt5QuickControls2_INCLUDE_DIRS})
-
 add_library(EStopSystem SHARED src/estop_system.cpp)
+target_include_directories(
+  EStopSystem PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                     $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 ament_target_dependencies(EStopSystem rclcpp std_msgs std_srvs)
 target_link_libraries(EStopSystem gz-sim8 gz-plugin2)
 
@@ -45,6 +45,9 @@ qt5_add_resources(resources_rcc src/gui/EStop.qrc)
 
 add_library(EStop SHARED include/husarion_ugv_gazebo/gui/e_stop.hpp
                          src/gui/e_stop.cpp ${resources_rcc})
+target_include_directories(
+  EStop PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+               $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 ament_target_dependencies(EStop rclcpp std_msgs std_srvs)
 target_link_libraries(
   EStop
@@ -56,6 +59,9 @@ target_link_libraries(
   ${Qt5QuickControls2_LIBRARIES})
 
 add_library(LEDStrip SHARED src/led_strip.cpp)
+target_include_directories(
+  LEDStrip PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 ament_target_dependencies(LEDStrip realtime_tools)
 target_link_libraries(LEDStrip gz-sim8 gz-msgs10 gz-plugin2 gz-transport13)
 

--- a/husarion_ugv_hardware_interfaces/CMakeLists.txt
+++ b/husarion_ugv_hardware_interfaces/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 
 # Handle superbuild first
 option(USE_SUPERBUILD "Whether or not a superbuild should be invoked" ON)
@@ -40,8 +40,6 @@ foreach(PACKAGE IN ITEMS ${PACKAGE_DEPENDENCIES})
   find_package(${PACKAGE} REQUIRED)
 endforeach()
 
-include_directories(include)
-
 generate_parameter_library(phidgets_spatial_parameters
                            src/phidgets_spatial_parameters.yaml)
 
@@ -69,6 +67,9 @@ add_library(
   src/robot_system/panther_system.cpp
   src/robot_system/ugv_system.cpp
   src/utils.cpp)
+target_include_directories(
+  ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                         $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 ament_target_dependencies(${PROJECT_NAME} ${PACKAGE_DEPENDENCIES})
 target_link_libraries(${PROJECT_NAME} PkgConfig::LIBLELY_COAPP
                       PkgConfig::LIBGPIOD phidgets_spatial_parameters)
@@ -351,6 +352,32 @@ if(BUILD_TESTING)
                           PkgConfig::LIBLELY_COAPP)
 
   endif()
+
+  set(PROJECT_TEST_TARGETS
+      ${PROJECT_NAME}_test_utils
+      ${PROJECT_NAME}_test_roboteq_error_filter
+      ${PROJECT_NAME}_test_roboteq_data_converters
+      ${PROJECT_NAME}_test_gpiod_controller
+      ${PROJECT_NAME}_test_ugv_system
+      ${PROJECT_NAME}_test_lynx_system
+      ${PROJECT_NAME}_test_panther_system)
+
+  if(TEST_INTEGRATION)
+    list(
+      APPEND
+      PROJECT_TEST_TARGETS
+      ${PROJECT_NAME}_test_system_ros_interface
+      ${PROJECT_NAME}_test_canopen_manager
+      ${PROJECT_NAME}_test_lynx_robot_driver
+      ${PROJECT_NAME}_test_panther_robot_driver
+      ${PROJECT_NAME}_test_roboteq_driver
+      ${PROJECT_NAME}_test_roboteq_robot_driver)
+  endif()
+
+  foreach(TEST_TARGET IN LISTS PROJECT_TEST_TARGETS)
+    target_include_directories(${TEST_TARGET}
+                               PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+  endforeach()
 
 endif()
 

--- a/husarion_ugv_lights/CMakeLists.txt
+++ b/husarion_ugv_lights/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 project(husarion_ugv_lights)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -24,18 +24,24 @@ foreach(PACKAGE IN ITEMS ${PACKAGE_DEPENDENCIES})
   find_package(${PACKAGE} REQUIRED)
 endforeach()
 
-include_directories(include)
-
 pluginlib_export_plugin_description_file(${PROJECT_NAME} plugins.xml)
 
 add_library(animation_plugins SHARED src/animation/image_animation.cpp
                                      src/animation/moving_image_animation.cpp)
+target_include_directories(
+  animation_plugins
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 
 ament_target_dependencies(animation_plugins husarion_ugv_utils pluginlib)
 target_link_libraries(animation_plugins png yaml-cpp)
 
 add_library(lights_driver_node_component SHARED src/lights_driver_node.cpp
                                                 src/apa102.cpp)
+target_include_directories(
+  lights_driver_node_component
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 ament_target_dependencies(
   lights_driver_node_component
   diagnostic_updater
@@ -58,6 +64,10 @@ add_library(
   src/led_components/segment_converter.cpp
   src/led_components/segment_layer.cpp
   src/led_components/segment_queue_layer.cpp)
+target_include_directories(
+  lights_controller_node_component
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 ament_target_dependencies(
   lights_controller_node_component
   husarion_ugv_msgs

--- a/husarion_ugv_localization/CMakeLists.txt
+++ b/husarion_ugv_localization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 project(husarion_ugv_localization)
 
 find_package(ament_cmake REQUIRED)

--- a/husarion_ugv_manager/CMakeLists.txt
+++ b/husarion_ugv_manager/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 project(husarion_ugv_manager)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -27,7 +27,10 @@ foreach(PACKAGE IN ITEMS ${PACKAGE_DEPENDENCIES})
   find_package(${PACKAGE} REQUIRED)
 endforeach()
 
-include_directories(include)
+function(target_project_include_directories target)
+  target_include_directories(${target}
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+endfunction()
 
 add_library(call_set_bool_service_bt_node SHARED
             src/plugins/action/call_set_bool_service_node.cpp)
@@ -71,12 +74,14 @@ add_library(execute_command_bt_node SHARED
 list(APPEND plugin_libs execute_command_bt_node)
 
 foreach(bt_plugin ${plugin_libs})
+  target_project_include_directories(${bt_plugin})
   target_compile_definitions(${bt_plugin} PRIVATE BT_PLUGIN_EXPORT)
   ament_target_dependencies(${bt_plugin} ${PACKAGE_DEPENDENCIES})
 endforeach()
 
 add_executable(safety_manager_node src/safety_manager_node_main.cpp
                                    src/safety_manager_node.cpp)
+target_project_include_directories(safety_manager_node)
 ament_target_dependencies(
   safety_manager_node
   behaviortree_ros2
@@ -95,6 +100,7 @@ target_link_libraries(safety_manager_node ${plugin_libs}
 
 add_executable(lights_manager_node src/lights_manager_node_main.cpp
                                    src/lights_manager_node.cpp)
+target_project_include_directories(lights_manager_node)
 ament_target_dependencies(
   lights_manager_node
   behaviortree_ros2
@@ -313,6 +319,18 @@ if(BUILD_TESTING)
     tf2_geometry_msgs)
   target_link_libraries(${PROJECT_NAME}_test_safety_behavior_tree
                         safety_manager_parameters OpenSSL::SSL)
+
+  set(PROJECT_TEST_TARGETS
+      ${plugin_tests}
+      ${PROJECT_NAME}_test_behavior_tree_utils
+      ${PROJECT_NAME}_test_behavior_tree_manager
+      ${PROJECT_NAME}_test_lights_manager_node
+      ${PROJECT_NAME}_test_lights_behavior_tree
+      ${PROJECT_NAME}_test_safety_manager_node
+      ${PROJECT_NAME}_test_safety_behavior_tree)
+  foreach(TEST_TARGET IN LISTS PROJECT_TEST_TARGETS)
+    target_project_include_directories(${TEST_TARGET})
+  endforeach()
 endif()
 
 ament_export_libraries(${plugin_libs})

--- a/husarion_ugv_msgs/CMakeLists.txt
+++ b/husarion_ugv_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 project(husarion_ugv_msgs)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/husarion_ugv_teleop/CMakeLists.txt
+++ b/husarion_ugv_teleop/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 project(husarion_ugv_teleop)
 
 find_package(ament_cmake REQUIRED)

--- a/husarion_ugv_utils/CMakeLists.txt
+++ b/husarion_ugv_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22.1)
 project(husarion_ugv_utils)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
### Description

- Replaces global `include_directories()` usage with `target_include_directories()`
- Updates `cmake_minimum_required` from 3.11 to 3.22.1 across all packages.

### Requirements

- [ ] (Dependency PR)
- [ ] Backport
- [x] Code style guidelines followed
- [ ] Documentation updated
- [ ] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [ ] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Updated the minimum required CMake version to 3.20 across project packages.
  * Improved build consistency by applying include paths directly to relevant components and tests.
  * Refined test configuration and package dependency handling.
  * Clarified separation between build-time and install-time include paths.
  * Updated simulator integration and plugin build configuration for improved compatibility with current tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->