### PR TITLE
Upgrade behaviortree_ros2 to 0.3.0

### DIFF
--- a/husarion_ugv/hardware_deps.repos
+++ b/husarion_ugv/hardware_deps.repos
@@ -6,7 +6,7 @@ repositories:
   behaviortree_ros2:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.ROS2
-    version: 7a6ace6424adaa81737b95d20d81e1e8c0782ed7
+    version: 0.3.0
   husarion_controllers:
     type: git
     url: https://github.com/husarion/husarion_controllers

--- a/husarion_ugv/simulation_deps.repos
+++ b/husarion_ugv/simulation_deps.repos
@@ -6,7 +6,7 @@ repositories:
   behaviortree_ros2:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.ROS2
-    version: 7a6ace6424adaa81737b95d20d81e1e8c0782ed7
+    version: 0.3.0
   husarion_controllers:
     type: git
     url: https://github.com/husarion/husarion_controllers


### PR DESCRIPTION
### Description

- Include the commits from Oct 29, 2025: https://github.com/BehaviorTree/BehaviorTree.ROS2/commits/0.3.0/
- Removes usage of deprecated code

### Requirements

- [x] (Dependency PR)
- [ ] Backport
- [x] Code style guidelines followed
- [ ] Documentation updated
- [x] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [ ] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the BehaviorTree dependency to release version 0.3.0 for both hardware and simulation environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->