### PR TITLE
Modernize hardware initialization

### DIFF
--- a/husarion_ugv_hardware_interfaces/include/husarion_ugv_hardware_interfaces/phidget_imu_sensor/phidget_imu_sensor.hpp
+++ b/husarion_ugv_hardware_interfaces/include/husarion_ugv_hardware_interfaces/phidget_imu_sensor/phidget_imu_sensor.hpp
@@ -57,7 +57,8 @@ class PhidgetImuSensor : public hardware_interface::SensorInterface
 public:
   RCLCPP_SHARED_PTR_DEFINITIONS(PhidgetImuSensor)
 
-  CallbackReturn on_init(const hardware_interface::HardwareInfo & hardware_info) override;
+  CallbackReturn on_init(
+    const hardware_interface::HardwareComponentInterfaceParams & params) override;
   CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;
   CallbackReturn on_cleanup(const rclcpp_lifecycle::State & previous_state) override;
   CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;

--- a/husarion_ugv_hardware_interfaces/include/husarion_ugv_hardware_interfaces/robot_system/ugv_system.hpp
+++ b/husarion_ugv_hardware_interfaces/include/husarion_ugv_hardware_interfaces/robot_system/ugv_system.hpp
@@ -61,7 +61,8 @@ public:
 
   virtual ~UGVSystem() = default;
 
-  CallbackReturn on_init(const hardware_interface::HardwareInfo & hardware_info) override;
+  CallbackReturn on_init(
+    const hardware_interface::HardwareComponentInterfaceParams & params) override;
   CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;
   CallbackReturn on_cleanup(const rclcpp_lifecycle::State & previous_state) override;
   CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;

--- a/husarion_ugv_hardware_interfaces/src/phidget_imu_sensor/phidget_imu_sensor.cpp
+++ b/husarion_ugv_hardware_interfaces/src/phidget_imu_sensor/phidget_imu_sensor.cpp
@@ -48,9 +48,10 @@
 namespace husarion_ugv_hardware_interfaces
 {
 
-CallbackReturn PhidgetImuSensor::on_init(const hardware_interface::HardwareInfo & hardware_info)
+CallbackReturn PhidgetImuSensor::on_init(
+  const hardware_interface::HardwareComponentInterfaceParams & params)
 {
-  if (hardware_interface::SensorInterface::on_init(hardware_info) != CallbackReturn::SUCCESS) {
+  if (hardware_interface::SensorInterface::on_init(params) != CallbackReturn::SUCCESS) {
     return CallbackReturn::ERROR;
   }
 

--- a/husarion_ugv_hardware_interfaces/src/robot_system/ugv_system.cpp
+++ b/husarion_ugv_hardware_interfaces/src/robot_system/ugv_system.cpp
@@ -37,9 +37,10 @@
 namespace husarion_ugv_hardware_interfaces
 {
 
-CallbackReturn UGVSystem::on_init(const hardware_interface::HardwareInfo & hardware_info)
+CallbackReturn UGVSystem::on_init(
+  const hardware_interface::HardwareComponentInterfaceParams & params)
 {
-  if (hardware_interface::SystemInterface::on_init(hardware_info) != CallbackReturn::SUCCESS) {
+  if (hardware_interface::SystemInterface::on_init(params) != CallbackReturn::SUCCESS) {
     return CallbackReturn::ERROR;
   }
 

--- a/husarion_ugv_hardware_interfaces/test/integration/phidget_imu_sensor/test_phidget_imu_sensor.cpp
+++ b/husarion_ugv_hardware_interfaces/test/integration/phidget_imu_sensor/test_phidget_imu_sensor.cpp
@@ -29,6 +29,19 @@
 #include "husarion_ugv_hardware_interfaces/phidget_imu_sensor/phidget_imu_sensor.hpp"
 #include "husarion_ugv_utils/test/test_utils.hpp"
 
+namespace
+{
+
+hardware_interface::HardwareComponentInterfaceParams MakeHardwareComponentParams(
+  const hardware_interface::HardwareInfo & hardware_info)
+{
+  hardware_interface::HardwareComponentInterfaceParams params;
+  params.hardware_info = hardware_info;
+  return params;
+}
+
+}  // namespace
+
 class PhidgetImuSensorWrapper : public husarion_ugv_hardware_interfaces::PhidgetImuSensor
 {
 public:
@@ -422,7 +435,8 @@ TEST_F(TestPhidgetImuSensor, CheckMagnitudeWrongValueAndCalibration)
   info.sensors.push_back(sensor_info);
   info = CreateCorrectInterfaces(info);
 
-  ASSERT_EQ(imu_sensor_->on_init(info), CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    imu_sensor_->on_init(MakeHardwareComponentParams(info)), CallbackReturn::SUCCESS);
 
   double magnitude[3];
   magnitude[0] = husarion_ugv_hardware_interfaces::PhidgetImuSensor::KImuMagneticFieldUnknownValue;
@@ -449,7 +463,8 @@ TEST_F(TestPhidgetImuSensor, CheckCalibrationOnDataCallbackAndAlgorithmInitializ
   info = CreateCorrectInterfaces(info);
   info = AddMadgwickParameters(info);
 
-  ASSERT_EQ(imu_sensor_->on_init(info), CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    imu_sensor_->on_init(MakeHardwareComponentParams(info)), CallbackReturn::SUCCESS);
   double magnitude[3], acceleration[3], gyration[3];
   magnitude[0] = husarion_ugv_hardware_interfaces::PhidgetImuSensor::KImuMagneticFieldUnknownValue;
   const auto fake_wrong_magnitude_parsed = imu_sensor_->ParseMagnitude(magnitude);
@@ -491,7 +506,8 @@ TEST_F(TestPhidgetImuSensor, CheckReconnection)
   info = CreateCorrectInterfaces(info);
   info = AddMadgwickParameters(info);
 
-  ASSERT_EQ(imu_sensor_->on_init(info), CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    imu_sensor_->on_init(MakeHardwareComponentParams(info)), CallbackReturn::SUCCESS);
   double magnitude[3], acceleration[3], gyration[3];
   magnitude[0] = husarion_ugv_hardware_interfaces::PhidgetImuSensor::KImuMagneticFieldUnknownValue;
 

--- a/husarion_ugv_hardware_interfaces/test/unit/robot_system/test_lynx_system.cpp
+++ b/husarion_ugv_hardware_interfaces/test/unit/robot_system/test_lynx_system.cpp
@@ -93,7 +93,8 @@ public:
     hardware_info_ = husarion_ugv_hardware_interfaces_test::GenerateDefaultHardwareInfo();
     hardware_info_.hardware_parameters.emplace("driver_can_id", "1");
 
-    lynx_system_->on_init(hardware_info_);
+    lynx_system_->on_init(
+      husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_));
     lynx_system_->on_configure(rclcpp_lifecycle::State());
   }
 

--- a/husarion_ugv_hardware_interfaces/test/unit/robot_system/test_panther_system.cpp
+++ b/husarion_ugv_hardware_interfaces/test/unit/robot_system/test_panther_system.cpp
@@ -108,7 +108,8 @@ public:
     hardware_info_.hardware_parameters.emplace("front_driver_can_id", "1");
     hardware_info_.hardware_parameters.emplace("rear_driver_can_id", "2");
 
-    panther_system_->on_init(hardware_info_);
+    panther_system_->on_init(
+      husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_));
     panther_system_->on_configure(rclcpp_lifecycle::State());
   }
 

--- a/husarion_ugv_hardware_interfaces/test/unit/robot_system/test_ugv_system.cpp
+++ b/husarion_ugv_hardware_interfaces/test/unit/robot_system/test_ugv_system.cpp
@@ -127,7 +127,8 @@ TEST_F(TestUGVSystem, OnInit)
 {
   EXPECT_CALL(*ugv_system_, ReadCANopenSettingsDriverCANIDs()).Times(1);
 
-  auto callback_return = ugv_system_->on_init(hardware_info_);
+  auto callback_return = ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_));
 
   EXPECT_EQ(callback_return, hardware_interface::CallbackReturn::SUCCESS);
 }
@@ -136,7 +137,8 @@ TEST_F(TestUGVSystem, OnConfigure)
 {
   rclcpp::init(0, nullptr);
 
-  ASSERT_NO_THROW(ugv_system_->on_init(hardware_info_));
+  ASSERT_NO_THROW(ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_)));
 
   EXPECT_CALL(*ugv_system_, DefineRobotDriver()).Times(1);
   EXPECT_CALL(*ugv_system_, ConfigureGPIOController()).Times(1);
@@ -155,7 +157,8 @@ TEST_F(TestUGVSystem, OnCleanup)
 {
   rclcpp::init(0, nullptr);
 
-  ASSERT_NO_THROW(ugv_system_->on_init(hardware_info_));
+  ASSERT_NO_THROW(ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_)));
   ASSERT_NO_THROW(ugv_system_->on_configure(rclcpp_lifecycle::State()));
 
   EXPECT_CALL(*ugv_system_->GetMockRobotDriver(), Deinitialize()).Times(1);
@@ -170,7 +173,8 @@ TEST_F(TestUGVSystem, OnActivate)
 {
   rclcpp::init(0, nullptr);
 
-  ASSERT_NO_THROW(ugv_system_->on_init(hardware_info_));
+  ASSERT_NO_THROW(ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_)));
   ASSERT_NO_THROW(ugv_system_->on_configure(rclcpp_lifecycle::State()));
   auto callback_return = ugv_system_->on_activate(rclcpp_lifecycle::State());
 
@@ -183,7 +187,8 @@ TEST_F(TestUGVSystem, OnDeactivate)
 {
   rclcpp::init(0, nullptr);
 
-  ASSERT_NO_THROW(ugv_system_->on_init(hardware_info_));
+  ASSERT_NO_THROW(ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_)));
   ASSERT_NO_THROW(ugv_system_->on_configure(rclcpp_lifecycle::State()));
   ASSERT_NO_THROW(ugv_system_->on_activate(rclcpp_lifecycle::State()));
 
@@ -199,7 +204,8 @@ TEST_F(TestUGVSystem, OnShutdown)
 {
   rclcpp::init(0, nullptr);
 
-  ASSERT_NO_THROW(ugv_system_->on_init(hardware_info_));
+  ASSERT_NO_THROW(ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_)));
   ASSERT_NO_THROW(ugv_system_->on_configure(rclcpp_lifecycle::State()));
 
   EXPECT_CALL(*ugv_system_->GetMockEStop(), TriggerEStop()).Times(1);
@@ -215,7 +221,8 @@ TEST_F(TestUGVSystem, OnError)
 {
   rclcpp::init(0, nullptr);
 
-  ASSERT_NO_THROW(ugv_system_->on_init(hardware_info_));
+  ASSERT_NO_THROW(ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_)));
   ASSERT_NO_THROW(ugv_system_->on_configure(rclcpp_lifecycle::State()));
 
   EXPECT_CALL(*ugv_system_->GetMockEStop(), TriggerEStop()).Times(1);
@@ -231,7 +238,8 @@ TEST_F(TestUGVSystem, ExportStateInterfacesInitialValues)
 {
   std::vector<std::string> prefixes = {"fl", "fr", "rl", "rr"};
 
-  ASSERT_NO_THROW(ugv_system_->on_init(hardware_info_));
+  ASSERT_NO_THROW(ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_)));
 
   std::vector<hardware_interface::StateInterface> state_interfaces =
     ugv_system_->export_state_interfaces();
@@ -268,7 +276,8 @@ TEST_F(TestUGVSystem, ExportStateInterfaces)
   std::vector<double> velocity = {5.0, 6.0, 7.0, 8.0};
   std::vector<double> effort = {9.0, 10.0, 11.0, 12.0};
 
-  ASSERT_NO_THROW(ugv_system_->on_init(hardware_info_));
+  ASSERT_NO_THROW(ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_)));
 
   ugv_system_->SetHwStatePosition(position);
   ugv_system_->SetHwStateVelocity(velocity);
@@ -290,7 +299,8 @@ TEST_F(TestUGVSystem, ExportCommandInterfacesInitialValues)
 {
   std::vector<std::string> prefixes = {"fl", "fr", "rl", "rr"};
 
-  ASSERT_NO_THROW(ugv_system_->on_init(hardware_info_));
+  ASSERT_NO_THROW(ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_)));
 
   std::vector<hardware_interface::CommandInterface> command_interfaces =
     ugv_system_->export_command_interfaces();
@@ -321,7 +331,8 @@ TEST_F(TestUGVSystem, ExportCommandInterfaces)
 {
   std::vector<double> velocity = {1.0, 2.0, 3.0, 4.0};
 
-  ASSERT_NO_THROW(ugv_system_->on_init(hardware_info_));
+  ASSERT_NO_THROW(ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_)));
 
   ugv_system_->SetHwCommandVelocity(velocity);
 
@@ -339,7 +350,8 @@ TEST_F(TestUGVSystem, Read)
 {
   rclcpp::init(0, nullptr);
 
-  ASSERT_NO_THROW(ugv_system_->on_init(hardware_info_));
+  ASSERT_NO_THROW(ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_)));
   ASSERT_NO_THROW(ugv_system_->on_configure(rclcpp_lifecycle::State()));
   ASSERT_NO_THROW(ugv_system_->on_activate(rclcpp_lifecycle::State()));
 
@@ -367,7 +379,8 @@ TEST_F(TestUGVSystem, Write)
   const auto velocity = std::vector<float>{1.0, 2.0, 3.0, 4.0};
 
   // System is deactivated, no speed commands sent
-  ASSERT_NO_THROW(ugv_system_->on_init(hardware_info_));
+  ASSERT_NO_THROW(ugv_system_->on_init(
+    husarion_ugv_hardware_interfaces_test::MakeHardwareComponentParams(hardware_info_)));
   ASSERT_NO_THROW(ugv_system_->on_configure(rclcpp_lifecycle::State()));
 
   EXPECT_CALL(*ugv_system_->GetMockEStop(), ReadEStopState()).Times(1);

--- a/husarion_ugv_hardware_interfaces/test/utils/system_test_utils.hpp
+++ b/husarion_ugv_hardware_interfaces/test/utils/system_test_utils.hpp
@@ -22,6 +22,8 @@
 
 #include <gmock/gmock.h>
 
+#include <hardware_interface/types/hardware_component_interface_params.hpp>
+
 #include "husarion_ugv_hardware_interfaces/robot_system/gpio/gpio_controller.hpp"
 #include "husarion_ugv_hardware_interfaces/robot_system/robot_driver/driver.hpp"
 #include "husarion_ugv_hardware_interfaces/robot_system/robot_driver/robot_driver.hpp"
@@ -31,6 +33,14 @@
 
 namespace husarion_ugv_hardware_interfaces_test
 {
+
+inline hardware_interface::HardwareComponentInterfaceParams MakeHardwareComponentParams(
+  const hardware_interface::HardwareInfo & hardware_info)
+{
+  hardware_interface::HardwareComponentInterfaceParams params;
+  params.hardware_info = hardware_info;
+  return params;
+}
 
 class MockRobotDriver : public husarion_ugv_hardware_interfaces::RobotDriverInterface
 {


### PR DESCRIPTION
### Description

- Update all hardware interface `on_init` overrides from `HardwareInfo` to `HardwareComponentInterfaceParams`

### Requirements

- [ ] (Dependency PR)
- [ ] Backport
- [x] Code style guidelines followed
- [ ] Documentation updated
- [ ] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [ ] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Updated robot, sensor, and emergency-stop hardware initialization to support the current ros2_control interface.
  - Existing initialization behavior and safety-state handling remain unchanged.

- **Tests**
  - Updated hardware integration and unit tests to use the revised initialization parameters.
  - Added shared test support for constructing the required hardware component parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->